### PR TITLE
Target JVM by default

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,4 @@
-{:deps {mvxcvi/alphabase {:mvn/version "2.1.1"}
-        org.clojure/tools.namespace  #_{:local/root "/Users/borkdude/Dropbox/dev/clojure/tools.namespace"}
-        {:git/url "https://github.com/babashka/tools.namespace"
-         :git/sha "a13b037215e21a2e71aa34b27e1dd52c801a2a7b"}}}
+{:deps {babashka/fs {:mvn/version "0.1.2"}
+        babashka/process {:mvn/version "0.1.0"}
+        mvxcvi/alphabase {:mvn/version "2.1.1"}
+        org.clojure/tools.namespace {:mvn/version "1.2.0"}}}


### PR DESCRIPTION
Make project self-sufficient wrt deps.

This is needed to require dejavu as dep in other projects using regular org.clojure/tools.namespace. To target babashka we'll configure babashka tools.namespace dep in bb.edn files of projects using it (e.g. Ductile).